### PR TITLE
an update that enables full vpn+proxy functionality using sshuttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ num_of_instances, The number of instances you'd like to launch.
 
 ### Debian-based systems
 
-```apt install python3-boto python3-netifaces ```
+```apt install python3-boto python3-netifaces sshuttle ```
 
 ### For those who prefer Pip
 

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -811,14 +811,14 @@ def main():
         error("There may be config in your AWS console to tidy up but no local changes were made")
         exit()
 
-    warning("Starting %s instances, waiting about 4 minutes for them to fully boot" % args.num_of_instances)
+    warning("Starting %s instances, waiting about 2 minutes for them to fully boot" % args.num_of_instances)
 
-    # sleep for 4 minutes while booting images
+    # sleep for 2 minutes while booting images
     for i in range(21):
         sys.stdout.write('\r')
         sys.stdout.write("[%-20s] %d%%" % ('=' * i, 5 * i))
         sys.stdout.flush()
-        time.sleep(11.5)
+        time.sleep(5.75)
     print("\n")
     # Add tag name to instance for better management
     for instance in reservations.instances:
@@ -1034,6 +1034,9 @@ if not os.path.isfile("/sbin/iptables-restore"):
     exit()
 if not os.path.isfile("/sbin/iptables"):
     error("Could not find /sbin/iptables")
+    exit()
+if not os.path.isfile("/usr/bin/sshuttle"):
+    error("Could not find /usr/bin/sshuttle")
     exit()
 
 # Check args

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -878,12 +878,12 @@ def main():
                     localcmdsudoprefix + "ifconfig tun%s 172.31.%s.2 netmask 255.255.255.0" % (tunnel_id, tunnel_id))
         time.sleep(0.5)
         # Establish tunnel interface
-        #sshcmd = "ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o " \
-        #         "ServerAliveInterval=50 ubuntu@%s &" % \
-        #         (homeDir, keyName, tunnel_id, tunnel_id, tunnels[tunnel_id]['pub_ip'])
-        sshcmd = "sshuttle --dns -r ubuntu@%s 0/0 -x %s:22 --ssh-cmd " \
-                 "'ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=50' &" % \
-                 (tunnels[tunnel_id]['pub_ip'], tunnels[tunnel_id]['pub_ip'], homeDir, keyName, tunnel_id, tunnel_id, tunnels[tunnel_id]['pub_ip'])
+        sshcmd = "ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o " \
+                 "ServerAliveInterval=50 ubuntu@%s &" % \
+                 (homeDir, keyName, tunnel_id, tunnel_id, tunnels[tunnel_id]['pub_ip'])
+        #sshcmd = "sshuttle --dns -r ubuntu@%s 0/0 -x %s:22 --ssh-cmd " \
+        #         "'ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=50' &" \
+        #         % (tunnels[tunnel_id]['pub_ip'], tunnels[tunnel_id]['pub_ip'], homeDir, keyName, tunnel_id, tunnel_id)
 
         debug("SHELL CMD (remote): " + sshcmd)
         retry_cnt = 0

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -10,7 +10,7 @@ import sys
 if sys.version_info.major != 3 or sys.version_info.minor < 5:
     print("This script needs Python >= 3.5.  You are running Python %s" % sys.version)
     exit()
-import argparse
+import argparse 
 import datetime
 import hashlib
 import os

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -142,12 +142,17 @@ def cleanup(proxy=None, cannon=None):
 
     for tunnel_id, tunnel in tunnels.items():
         # Killing ssh tunnel
-        run_sys_cmd("Killing ssh tunnel (tun%s)" % tunnel_id, True,
-                    "kill $(ps -ef | grep ssh | grep %s | awk '{print $2}')" % tunnels[tunnel_id]['pub_ip'], False)
+        #run_sys_cmd("Killing ssh tunnel (tun%s)" % tunnel_id, True, localcmdsudoprefix +
+        #            "kill $(ps -ef | grep ssh | grep %s | grep ssh-cmd | awk '{print $2}')" % tunnels[tunnel_id]['pub_ip'], False)
+        #run_sys_cmd("Killing ssh tunnel (tun%s)" % tunnel_id, True, localcmdsudoprefix +
+        #            "kill $(ps -ef | grep ssh | grep %s | awk '{print $2}')" % tunnels[tunnel_id]['pub_ip'], False)
+        ##########
+        #for some reason this command fails every time. gonna let it just figure out the server is dead from the keepalive, or from the destruction of the interface
+        ##########
 
         # Delete local routes
         run_sys_cmd("Delete route %s dev %s" % (tunnels[tunnel_id]['pub_ip'], networkInterface), True, localcmdsudoprefix +
-                    "route del %s dev %s" % (tunnels[tunnel_id]['pub_ip'], networkInterface), report_errors=False)
+                    "route del %s dev %s" % (tunnels[tunnel_id]['pub_ip'], networkInterface), report_errors=True)
 
         # Destroying local tun interfaces
         run_sys_cmd("Destroying local tun interfaces", True, localcmdsudoprefix +
@@ -164,7 +169,7 @@ def cleanup(proxy=None, cannon=None):
                 (localcmdsudoprefix, iptablesName))
 
     # Replace the custom default route with a standard one that makes sense
-    run_sys_cmd("Re-adding normal default route", True, localcmdsudoprefix + "ip route replace default via %s dev %s" %
+    run_sys_cmd("Restoring normal default route", True, localcmdsudoprefix + "ip route replace default via %s dev %s" %
                 (defaultgateway, networkInterface))
 
     # Remove local ssh key
@@ -192,8 +197,8 @@ def cleanup(proxy=None, cannon=None):
             debug("Attempting to terminate instance: %s" % str(instance.id))
             instance.terminate()
 
-        warning("Pausing for 120 seconds so instances can properly terminate.....")
-        time.sleep(120)
+        warning("Pausing for 4 minutes so instances can properly terminate.....")
+        time.sleep(240)
     conn.get_all_addresses(filters={"tag:Name": nameTag})
 
     # Detect Elastic IPs and remove them if needed
@@ -368,9 +373,16 @@ def rotate_host(target_tunnel_id, show_log=True):
     # marking ssh tunnel as inactive
     tunnels[target_tunnel_id]['tunnel_active'] = False
     # Killing ssh tunnel
-    run_sys_cmd("Killing ssh tunnel (tun%s)" % target_tunnel_id, True,
-                "kill $(ps -ef | grep ssh | grep %s | awk '{print $2}')" %
-                tunnels[target_tunnel_id]['pub_ip'], report_errors=False, show_log=show_log)
+    #run_sys_cmd("Killing ssh tunnel (tun%s)" % target_tunnel_id, True, localcmdsudoprefix +
+    #            "kill $(ps -ef | grep ssh | grep %s | grep ssh-cmd | awk '{print $2}')" %
+    #            tunnels[target_tunnel_id]['pub_ip'], report_errors=True, show_log=show_log)
+    #run_sys_cmd("Killing ssh tunnel (tun%s)" % target_tunnel_id, True, localcmdsudoprefix +
+    #            "kill $(ps -ef | grep ssh | grep %s | awk '{print $2}')" %
+    #            tunnels[target_tunnel_id]['pub_ip'], report_errors=True, show_log=show_log)
+    ##########
+    #for some reason this command fails every time. gonna let it just figure out the server is dead from the keepalive, or from the destruction of the interface
+    ##########
+
 
     # Remove iptables rule allowing SSH to EC2 Host
     run_sys_cmd("Remove iptables rule allowing SSH to EC2 Host (tun%s)" % target_tunnel_id, True, localcmdsudoprefix +
@@ -661,9 +673,9 @@ def cache_bust_thread_handler():
 ########################################################################################################################
 # Check OS reported state of tunnel
 ########################################################################################################################
-def tunnel_is_up(target_tunnel_id, show_log=False):
+def tunnel_is_up(target_tunnel_id, show_log=True):
     state = run_sys_cmd('Get status of the interface (tun%s)' % target_tunnel_id, True,
-                        'cat /sys/class/net/tun%s/operstate' % target_tunnel_id, report_errors=False, show_log=show_log)
+                        'cat /sys/class/net/tun%s/operstate' % target_tunnel_id, report_errors=True, show_log=show_log)
     if state.rstrip() == "up":
         return True
     else:
@@ -673,7 +685,7 @@ def tunnel_is_up(target_tunnel_id, show_log=False):
 ########################################################################################################################
 # Check tunnel actually transmits data to the outside
 ########################################################################################################################
-def tunnel_works(target_tunnel_id, show_log=False):
+def tunnel_works(target_tunnel_id, show_log=True):
     ping_result = run_sys_cmd('Ping a reliable target through tunnel (tun%s)' % target_tunnel_id, True,
                               "ping -I tun%s -c 1 -q 8.8.8.8 | grep 'packet loss' | awk '{print $6}'" %
                               target_tunnel_id, report_errors=False, show_log=show_log)
@@ -698,7 +710,7 @@ def tunnel_health_monitor_thread_handler():
         for target_tunnel_id in tunnels:
             if not tunnels[target_tunnel_id]['rotating_ip']:
                 # get the tunnel's status
-                target_tunnel_is_up = tunnel_is_up(target_tunnel_id, show_log=False)
+                target_tunnel_is_up = tunnel_is_up(target_tunnel_id, show_log=True)
                 # Do stuff if the link is not happy
                 if target_tunnel_is_up != tunnels[target_tunnel_id]['link_state_active']:
                     tunnels[target_tunnel_id]['link_state_active'] = not tunnels[target_tunnel_id]['link_state_active']
@@ -710,7 +722,7 @@ def tunnel_health_monitor_thread_handler():
                         tunnels[target_tunnel_id]['link_state_active'] = False
                         warning('Tunnel tun%s has been detected as down' % target_tunnel_id)
 
-                target_tunnel_works = tunnel_works(target_tunnel_id, show_log=False)
+                target_tunnel_works = tunnel_works(target_tunnel_id, show_log=True)
                 # Do stuff if the tunnel can't be used to ping
                 if target_tunnel_works != tunnels[target_tunnel_id]['tunnel_works']:
                     tunnels[target_tunnel_id]['tunnel_works'] = not tunnels[target_tunnel_id]['tunnel_works']
@@ -732,8 +744,8 @@ def tunnel_health_monitor_thread_handler():
                                 and tunnels[tunnel_id]['link_state_active'] and tunnels[tunnel_id]['tunnel_works']:
                             nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight 1 " % \
                                          (tunnel_id, tunnel_id)
-                    run_sys_cmd("Insert custom route (tunnel_health_monitor)", True,
-                                localcmdsudoprefix + nexthopcmd, show_log=False)
+                    run_sys_cmd_nr("Insert custom route (tunnel_health_monitor)", True,
+                                localcmdsudoprefix + nexthopcmd, show_log=True)
                     # update is no longer needed so reset the flag
                     update_needed = False
 
@@ -839,6 +851,10 @@ def main():
         tunnel_id += 1
     debug("Public IP's for all instances: %s" % public_ips)
 
+    # Save iptables
+    run_sys_cmd("Saving the current local IP tables state", True, localcmdsudoprefix +
+                "/sbin/iptables-save > /tmp/%s" % iptablesName)
+
     # Create ssh Tunnels for proxying
     success("Provisioning Hosts.....")
     for tunnel_id, tunnel in tunnels.items():
@@ -906,9 +922,9 @@ def main():
             if retcode != 0:
                 warning("Failed to establish ssh tunnel on %s. Retrying..." % tunnels[tunnel_id]['pub_ip'])
                 retry_cnt = retry_cnt + 1
-                time.sleep(1)
+                time.sleep(1+int(retry_cnt+1))
             else:
-                ssh_tunnel_pid = run_sys_cmd('Getting PID of newly created SSH tunnel', True, localcmdsudoprefix +
+                ssh_tunnel_pid = run_sys_cmd_nr('Getting PID of newly created SSH tunnel', True, localcmdsudoprefix +
                                              "ps -ef | grep ssh | grep %s | awk '{print $2}'" %
                                              tunnels[tunnel_id]['pub_ip']).split()[0]
                 # add pid entry to table
@@ -925,9 +941,9 @@ def main():
     run_sys_cmd("Enabling local ip forwarding (IPv4)", True, "echo 1 | " + localcmdsudoprefix +
                 "tee -a /proc/sys/net/ipv4/ip_forward")
 
-    # Save iptables
-    run_sys_cmd("Saving the current local IP tables state", True, localcmdsudoprefix +
-                "/sbin/iptables-save > /tmp/%s" % iptablesName)
+    # Save iptables ----- moved above "create ssh tables for proxying" since sshuttle alters the tables
+    #run_sys_cmd("Saving the current local IP tables state", True, localcmdsudoprefix +
+    #            "/sbin/iptables-save > /tmp/%s" % iptablesName)
 
     # Flush existing rules (1 of 3)
     run_sys_cmd("Flushing existing local iptables nat rules", True, localcmdsudoprefix + "iptables -w 2 -t nat -F")

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -143,7 +143,7 @@ def cleanup(proxy=None, cannon=None):
     for tunnel_id, tunnel in tunnels.items():
         # Killing ssh tunnel
         run_sys_cmd("Killing ssh tunnel (tun%s)" % tunnel_id, True,
-                    "kill $(ps -ef | grep ssh | grep %s | awk {'print $2'})" % tunnels[tunnel_id]['pub_ip'], False)
+                    "kill $(ps -ef | grep sshuttle | grep %s | awk {'print $2'})" % tunnels[tunnel_id]['pub_ip'], False)
 
         # Delete local routes
         run_sys_cmd("Delete route %s dev %s" % (tunnels[tunnel_id]['pub_ip'], networkInterface), True, localcmdsudoprefix +
@@ -368,7 +368,7 @@ def rotate_host(target_tunnel_id, show_log=True):
     tunnels[target_tunnel_id]['tunnel_active'] = False
     # Killing ssh tunnel
     run_sys_cmd("Killing ssh tunnel (tun%s)" % target_tunnel_id, True,
-                "kill $(ps -ef | grep ssh | grep %s | awk '{print $2}')" %
+                "kill $(ps -ef | grep sshuttle | grep %s | awk '{print $2}')" %
                 tunnels[target_tunnel_id]['pub_ip'], report_errors=False, show_log=show_log)
 
     # Remove iptables rule allowing SSH to EC2 Host

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -65,6 +65,35 @@ def run_sys_cmd(description, islocal, cmd, report_errors=True, show_log=True):
         target = 'local'
     else:
         target = 'remote'
+    retry_cnt = 0
+    while retry_cnt < 6:
+        if show_log:
+            debug(description)
+        if show_log:
+            debug("SHELL CMD (%s): %s" % (target, cmd))
+        retcode = run(cmd, shell=True, capture_output=True, text=True)
+        if retcode.returncode != 0:
+            if report_errors:
+                error("Failure: %s" % description + " Retrying...")
+                debug("Failed command output is: %s %s" % (str(retcode.stdout), str(retcode.stderr)))
+            retry_cnt = retry_cnt + 1
+            time.sleep(1.3)
+        else:
+            if show_log:
+                success("Success: %s" % description)
+            break
+        if retry_cnt == 6:
+            error("Giving up...")
+    return retcode.stdout
+
+########################################################################################################################
+# Run system commands (outside of Python) -- no retry
+########################################################################################################################
+def run_sys_cmd_nr(description, islocal, cmd, report_errors=True, show_log=True):
+    if islocal:
+        target = 'local'
+    else:
+        target = 'remote'
     if show_log:
         debug(description)
     if show_log:
@@ -77,7 +106,7 @@ def run_sys_cmd(description, islocal, cmd, report_errors=True, show_log=True):
     else:
         if show_log:
             success("Success: %s" % description)
-        return retcode.stdout
+    return retcode.stdout
 
 
 ########################################################################################################################

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -929,11 +929,6 @@ def main():
     run_sys_cmd("Allowing local connections to RFC1918 (3 of 4)", True, localcmdsudoprefix +
                 "iptables -w 2 -t nat -I POSTROUTING -d 10.0.0.0/8 -j RETURN")
 
-
-
-
-
-
     # do routing and ip tables for each of the tunnel hosts, including build the ECMP route
     nexthopcmd = "ip route replace default scope global "
     for tunnel_id, tunnel in tunnels.items():
@@ -970,8 +965,8 @@ def main():
 # System and Program Arguments
 ########################################################################################################################
 parser = argparse.ArgumentParser()
-parser.add_argument('-id', '--image-id', nargs='?', default='ami-02fd6382e5170796b',
-                    help="Amazon ami image ID.  Example: ami-02fd6382e5170796b. If not set, ami-02fd6382e5170796b.")
+parser.add_argument('-id', '--image-id', nargs='?', default='ami-0650b4d1b221600a5',
+                    help="Amazon ami image ID.  Example: ami-0650b4d1b221600a5. If not set, ami-0650b4d1b221600a5.")
 parser.add_argument('-t', '--image-type', nargs='?', default='t2.nano',
                     help="Amazon ami image type Example: t2.micro. If not set, defaults to t2.nano.")
 parser.add_argument('--region', nargs='?', default='us-east-2',

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -66,7 +66,7 @@ def run_sys_cmd(description, islocal, cmd, report_errors=True, show_log=True):
     else:
         target = 'remote'
     retry_cnt = 0
-    while retry_cnt < 6:
+    while retry_cnt < 10:
         if show_log:
             debug(description)
         if show_log:
@@ -77,7 +77,7 @@ def run_sys_cmd(description, islocal, cmd, report_errors=True, show_log=True):
                 error("Failure: %s" % description + " Retrying...")
                 debug("Failed command output is: %s %s" % (str(retcode.stdout), str(retcode.stderr)))
             retry_cnt = retry_cnt + 1
-            time.sleep(1.3)
+            time.sleep(1.5)
         else:
             if show_log:
                 success("Success: %s" % description)

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Original Author: Hans Lakhan
-# Current maintainer: Felix Ryan of You Gotta Hack That
+# Current maintainers: Felix Ryan of You Gotta Hack That, and Ellroch of OGLLC
 
 #######################
 import sys

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Original Author: Hans Lakhan
-# Current maintainer: Felix Ryan of You Gotta Hack That
-
+# Current maintainers: Felix Ryan of You Gotta Hack That, and Ellroch
 #######################
 import sys
 
@@ -61,6 +60,35 @@ def debug(msg):
 # Run system commands (outside of Python)
 ########################################################################################################################
 def run_sys_cmd(description, islocal, cmd, report_errors=True, show_log=True):
+    if islocal:
+        target = 'local'
+    else:
+        target = 'remote'
+    retry_cnt = 0
+    while retry_cnt < 6:
+        if show_log:
+            debug(description)
+        if show_log:
+            debug("SHELL CMD (%s): %s" % (target, cmd))
+        retcode = run(cmd, shell=True, capture_output=True, text=True)
+        if retcode.returncode != 0:
+            if report_errors:
+                error("Failure: %s" % description + " Retrying...")
+                debug("Failed command output is: %s %s" % (str(retcode.stdout), str(retcode.stderr)))
+            retry_cnt = retry_cnt + 1
+            time.sleep(1.3)
+        else:
+            if show_log:
+                success("Success: %s" % description)
+            break
+        if retry_cnt == 6:
+            error("Giving up...")
+    return retcode.stdout
+
+########################################################################################################################
+# Run system commands (outside of Python) -- no retry
+########################################################################################################################
+def run_sys_cmd_nr(description, islocal, cmd, report_errors=True, show_log=True):
     if islocal:
         target = 'local'
     else:
@@ -162,8 +190,9 @@ def cleanup(proxy=None, cannon=None):
             debug("Attempting to terminate instance: %s" % str(instance.id))
             instance.terminate()
 
-        warning("Pausing for 120 seconds so instances can properly terminate.....")
+        warning("Pausing for 2 minutes so instances can properly terminate.....")
         time.sleep(120)
+    print("\n")
     conn.get_all_addresses(filters={"tag:Name": nameTag})
 
     # Detect Elastic IPs and remove them if needed
@@ -285,7 +314,7 @@ def rotate_host(target_tunnel_id, show_log=True):
         if tunnels[tunnel_id]['route_active'] and tunnels[tunnel_id]['tunnel_active'] and \
                 tunnels[tunnel_id]['link_state_active'] and tunnels[tunnel_id]['tunnel_works'] and \
                 not tunnels[tunnel_id]['rotating_ip']:
-            nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
+            nexthopcmd = nexthopcmd + "nexthop via 172.31.%s.2 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
             # As we are using multipath routing and will do route cache-busting elsewhere
             # it is (probably?) good enough to do ECMP here (i.e. weight = 1 for all routes)
             routes_available = True
@@ -474,19 +503,18 @@ def rotate_host(target_tunnel_id, show_log=True):
 
             # Provision remote tun interface
             run_sys_cmd("Setting IP on remote tun adapter (tun%s)" % target_tunnel_id, False, sshbasecmd +
-                        "'sudo ifconfig tun%s 10.%s.254.1 netmask 255.255.255.252'" %
+                        "'sudo ifconfig tun%s 172.31.%s.2 netmask 255.255.0.0'" %
                         (target_tunnel_id, target_tunnel_id), show_log=show_log)
 
         # Check if we need the return route re-adding or not
         return_routes = run_sys_cmd("Check if we need the return route re-adding or not (tun%s)" % target_tunnel_id,
-                                    False, sshbasecmd + "'ip route list dev tun%s 10.%s.254.2/32'" %
+                                    False, sshbasecmd + "'ip route list dev tun%s 172.31.%s.2/16'" %
                                     (target_tunnel_id, target_tunnel_id), show_log=show_log)
         if return_routes == '':
             # Add return route back to us
             run_sys_cmd("Adding return route back to us (tun%s)" % target_tunnel_id, False, sshbasecmd +
-                        "'sudo route add 10.%s.254.2 dev tun%s'" %
+                        "'sudo route add 172.31.%s.2 dev tun%s'" %
                         (target_tunnel_id, target_tunnel_id), show_log=show_log)
-
         # Establish tunnel
         sshcmd = "ssh -i %s/.ssh/%s.pem -o StrictHostKeyChecking=no -w %s:%s -o TCPKeepAlive=yes -o " \
                  "ServerAliveInterval=50 ubuntu@%s &" % (homeDir, keyName, target_tunnel_id, target_tunnel_id, swapped_ip)
@@ -520,9 +548,9 @@ def rotate_host(target_tunnel_id, show_log=True):
 
         # Provision interface
         run_sys_cmd("Provision interface (tun%s)" % target_tunnel_id, True, localcmdsudoprefix +
-                    "ifconfig tun%s 10.%s.254.2 netmask 255.255.255.252" % (target_tunnel_id,
+                    "ifconfig tun%s 172.31.%s.2 netmask 255.255.0.0" % (target_tunnel_id,
                                                                             target_tunnel_id), show_log=show_log)
-        time.sleep(2)
+        time.sleep(1.3)
 
         # Allow local connections to the proxy server
         run_sys_cmd("Allow connections to our proxy servers (tun%s)" % target_tunnel_id, True, localcmdsudoprefix +
@@ -541,7 +569,7 @@ def rotate_host(target_tunnel_id, show_log=True):
             # don't include the host we are tearing down in the multipath routing or any others that have been disabled
             if tunnels[tunnel_id]['route_active'] and tunnels[tunnel_id]['tunnel_active'] and \
                     tunnels[tunnel_id]['link_state_active'] and tunnels[tunnel_id]['tunnel_works']:
-                nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
+                nexthopcmd = nexthopcmd + "nexthop via 172.31.%s.2 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
                 # As we are using multipath routing and will do route cache-busting elsewhere
                 # it is (probably?) good enough to do ECMP here (i.e. weight = 1 for all routes)
             elif not tunnels[tunnel_id]['rotating_ip']:
@@ -601,7 +629,7 @@ def cache_bust(show_log=True):
         if tunnels[tunnel_id]['tunnel_active'] and tunnels[tunnel_id]['route_active'] \
                 and tunnels[tunnel_id]['link_state_active'] and tunnels[tunnel_id]['tunnel_works']\
                 and not tunnels[tunnel_id]['rotating_ip']:
-            nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight %s " % \
+            nexthopcmd = nexthopcmd + "nexthop via 172.31.%s.2 dev tun%s weight %s " % \
                          (tunnel_id, tunnel_id, random_weights[tunnel_id])
         elif not tunnels[tunnel_id]['rotating_ip']:
             debug("Tunnel tun%s excluded route table (Route %s - Tunnel %s - Link %s - Transmits %s)" %
@@ -611,7 +639,7 @@ def cache_bust(show_log=True):
     # sleep for half a second to help ensure the subsequent cache flush doesn't happen before the route as been applied
     # there is apparent bias in this mechanism for one route over the others and it isn't clear as to what the cause is
     # hoping that it is just a race condition
-    time.sleep(0.5)
+    time.sleep(1)
     run_sys_cmd("Flushing route cache", True, localcmdsudoprefix + 'ip route flush cache', show_log=show_log)
 
 
@@ -622,7 +650,7 @@ def cache_bust_thread_handler():
     # check if the exit flag has been set
     while not exit_threads:
         cache_bust(show_log=False)
-        time.sleep(2)
+        time.sleep(1.2)
 
 
 ########################################################################################################################
@@ -697,9 +725,9 @@ def tunnel_health_monitor_thread_handler():
                         # only include the tunnel that are marked as active in the ECMP routing
                         if tunnels[tunnel_id]['tunnel_active'] and tunnels[tunnel_id]['route_active'] \
                                 and tunnels[tunnel_id]['link_state_active'] and tunnels[tunnel_id]['tunnel_works']:
-                            nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight 1 " % \
+                            nexthopcmd = nexthopcmd + "nexthop via 172.31.%s.2 dev tun%s weight 1 " % \
                                          (tunnel_id, tunnel_id)
-                    run_sys_cmd("Insert custom route (tunnel_health_monitor)", True,
+                    run_sys_cmd_nr("Insert custom route (tunnel_health_monitor)", True,
                                 localcmdsudoprefix + nexthopcmd, show_log=False)
                     # update is no longer needed so reset the flag
                     update_needed = False
@@ -779,14 +807,14 @@ def main():
         error("There may be config in your AWS console to tidy up but no local changes were made")
         exit()
 
-    warning("Starting %s instances, waiting about 4 minutes for them to fully boot" % args.num_of_instances)
+    warning("Starting %s instances, waiting about 2 minutes for them to fully boot" % args.num_of_instances)
 
-    # sleep for 4 minutes while booting images
+    # sleep for 2 minutes while booting images
     for i in range(21):
         sys.stdout.write('\r')
         sys.stdout.write("[%-20s] %d%%" % ('=' * i, 5 * i))
         sys.stdout.flush()
-        time.sleep(11.5)
+        time.sleep(5.75)
     print("\n")
     # Add tag name to instance for better management
     for instance in reservations.instances:
@@ -805,59 +833,47 @@ def main():
         public_ips = public_ips + instance.ip_address + " "
         tunnel_id += 1
     debug("Public IP's for all instances: %s" % public_ips)
-
     # Create ssh Tunnels for proxying
     success("Provisioning Hosts.....")
     for tunnel_id, tunnel in tunnels.items():
         log(tunnels[tunnel_id]['pub_ip'])
         sshbasecmd = "ssh -i %s/.ssh/%s.pem -o StrictHostKeyChecking=no ubuntu@%s " % (
             homeDir, keyName, tunnels[tunnel_id]['pub_ip'])
-
         # Enable Tunneling on the remote host
         run_sys_cmd("Enabling tunneling via SSH on %s (tun%s)" % (tunnels[tunnel_id]['pub_ip'], tunnel_id), False, sshbasecmd +
                     "'echo \"PermitTunnel yes\" | sudo tee -a  /etc/ssh/sshd_config'")
-
         # Restarting Service to take new config (you'd think a simple reload would be enough)
         run_sys_cmd("Restarting Service to take new config on %s (tun%s)" % (tunnels[tunnel_id]['pub_ip'], tunnel_id), False,
                     sshbasecmd +
                     "'sudo service ssh restart'")
-
         # Provision interface
         run_sys_cmd("Provisioning tun%s interface on %s" % (tunnel_id, tunnels[tunnel_id]['pub_ip']), False, sshbasecmd +
                     "'sudo ip tuntap add dev tun%s mode tun'" % tunnel_id)
-
         # Configure interface
         run_sys_cmd("Configuring tun%s interface on %s" % (tunnel_id, tunnels[tunnel_id]['pub_ip']), False, sshbasecmd +
-                    "'sudo ifconfig tun%s 10.%s.254.1 netmask 255.255.255.252'" % (tunnel_id, tunnel_id))
-
+                    "'sudo ifconfig tun%s 172.31.%s.2 netmask 255.255.0.0'" % (tunnel_id, tunnel_id))
         # Enable forwarding on remote host
         run_sys_cmd("Enable forwarding on remote host (tun%s)" % tunnel_id, False,
                     sshbasecmd + "'sudo su root -c \"echo 1 > "
                                  "/proc/sys/net/ipv4/ip_forward\"'")
-
         # Provision iptables on remote host
         run_sys_cmd("Provision iptables on remote host (tun%s)" % tunnel_id, False,
                     sshbasecmd + "'sudo iptables -t nat -A POSTROUTING "
                                  "-o eth0 -j MASQUERADE'")
-
         # Add return route back to us
         run_sys_cmd("Add return route back to us (tun%s)" % tunnel_id, False,
-                    sshbasecmd + "'sudo route add 10.%s.254.2 dev tun%s'"
+                    sshbasecmd + "'sudo route add 172.31.%s.2 dev tun%s'"
                     % (tunnel_id, tunnel_id))
-
         # Create tun interface
         run_sys_cmd("Creating local interface tun%s" % str(tunnel_id), True, localcmdsudoprefix +
                     "ip tuntap add dev tun%s mode tun" % str(tunnel_id))
-
         # Turn up our interface
         run_sys_cmd("Turning up interface tun%s" % str(tunnel_id), True, localcmdsudoprefix +
                     "ifconfig tun%s up" % tunnel_id)
-
         # Provision interface
-        run_sys_cmd("Assigning interface tun" + str(tunnel_id) + " ip of 10." + str(tunnel_id) + ".254.2", True,
-                    localcmdsudoprefix + "ifconfig tun%s 10.%s.254.2 netmask 255.255.255.252" % (tunnel_id, tunnel_id))
+        run_sys_cmd("Assigning interface tun" + str(tunnel_id) + " ip of 172.31." + str(tunnel_id) + ".2", True,
+                    localcmdsudoprefix + "ifconfig tun%s 172.31.%s.2 netmask 255.255.0.0" % (tunnel_id, tunnel_id))
         time.sleep(0.5)
-
         # Establish tunnel interface
         sshcmd = "ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o " \
                  "ServerAliveInterval=50 ubuntu@%s &" % \
@@ -902,16 +918,21 @@ def main():
     run_sys_cmd("Flushing all remaining local iptables rules", True, localcmdsudoprefix + "iptables -w 2 -F")
 
     # Allow local connections to RFC1918 (1 of 3)
-    run_sys_cmd("Allowing local connections to RFC1918 (1 of 3)", True, localcmdsudoprefix +
+    run_sys_cmd("Allowing local connections to RFC1918 (1 of 4)", True, localcmdsudoprefix +
                 "iptables -w 2 -t nat -I POSTROUTING -d 192.168.0.0/16 -j RETURN")
 
     # Allow local connections to RFC1918 (2 of 3)
-    run_sys_cmd("Allowing local connections to RFC1918 (2 of 3)", True, localcmdsudoprefix +
+    run_sys_cmd("Allowing local connections to RFC1918 (2 of 4)", True, localcmdsudoprefix +
                 "iptables -w 2 -t nat -I POSTROUTING -d 172.16.0.0/16 -j RETURN")
 
     # Allow local connections to RFC1918 (3 of 3)
-    run_sys_cmd("Allowing local connections to RFC1918 (3 of 3)", True, localcmdsudoprefix +
+    run_sys_cmd("Allowing local connections to RFC1918 (3 of 4)", True, localcmdsudoprefix +
                 "iptables -w 2 -t nat -I POSTROUTING -d 10.0.0.0/8 -j RETURN")
+
+
+
+
+
 
     # do routing and ip tables for each of the tunnel hosts, including build the ECMP route
     nexthopcmd = "ip route replace default scope global "
@@ -925,7 +946,7 @@ def main():
                     "iptables -w 2 -t nat -A POSTROUTING -o tun%s -j MASQUERADE " % tunnel_id)
 
         # Build ECMP route table command
-        nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
+        nexthopcmd = nexthopcmd + "nexthop via 172.31.%s.2 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
 
         # Mark route as active
         tunnels[tunnel_id]['route_active'] = True
@@ -949,12 +970,12 @@ def main():
 # System and Program Arguments
 ########################################################################################################################
 parser = argparse.ArgumentParser()
-parser.add_argument('-id', '--image-id', nargs='?', default='ami-d05e75b8',
-                    help="Amazon ami image ID.  Example: ami-d05e75b8. If not set, ami-d05e75b8.")
+parser.add_argument('-id', '--image-id', nargs='?', default='ami-02fd6382e5170796b',
+                    help="Amazon ami image ID.  Example: ami-02fd6382e5170796b. If not set, ami-02fd6382e5170796b.")
 parser.add_argument('-t', '--image-type', nargs='?', default='t2.nano',
-                    help="Amazon ami image type Example: t2.nano. If not set, defaults to t2.nano.")
-parser.add_argument('--region', nargs='?', default='us-east-1',
-                    help="Select the region: Example: us-east-1. If not set, defaults to us-east-1.")
+                    help="Amazon ami image type Example: t2.micro. If not set, defaults to t2.nano.")
+parser.add_argument('--region', nargs='?', default='us-east-2',
+                    help="Select the region: Example: us-east-2. If not set, defaults to us-east-2.")
 parser.add_argument('-r', action='store_true', help="Enable Rotating AMI hosts.")
 parser.add_argument('-b', action='store_true', help="Enable multipath cache busting.")
 parser.add_argument('-m', action='store_true', help="Disable the link state monitor thread.")
@@ -1130,4 +1151,4 @@ if __name__ == '__main__':
             for tunnel_id, tunnel in tunnels.items():
                 rotate_host(tunnel_id)
         # the below sleep is just to stop wild things from happening until proper timing control is implemented.
-        time.sleep(5)
+        time.sleep(3)

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -811,14 +811,14 @@ def main():
         error("There may be config in your AWS console to tidy up but no local changes were made")
         exit()
 
-    warning("Starting %s instances, waiting about 2 minutes for them to fully boot" % args.num_of_instances)
+    warning("Starting %s instances, waiting about 4 minutes for them to fully boot" % args.num_of_instances)
 
-    # sleep for 2 minutes while booting images
+    # sleep for 4 minutes while booting images
     for i in range(21):
         sys.stdout.write('\r')
         sys.stdout.write("[%-20s] %d%%" % ('=' * i, 5 * i))
         sys.stdout.flush()
-        time.sleep(5.75)
+        time.sleep(11.5)
     print("\n")
     # Add tag name to instance for better management
     for instance in reservations.instances:
@@ -1034,9 +1034,6 @@ if not os.path.isfile("/sbin/iptables-restore"):
     exit()
 if not os.path.isfile("/sbin/iptables"):
     error("Could not find /sbin/iptables")
-    exit()
-if not os.path.isfile("/usr/bin/sshuttle"):
-    error("Could not find /usr/bin/sshuttle")
     exit()
 
 # Check args

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Original Author: Hans Lakhan
-# Current maintainers: Felix Ryan of You Gotta Hack That, and Ellroch
+# Current maintainer: Felix Ryan of You Gotta Hack That
+
 #######################
 import sys
 
@@ -60,35 +61,6 @@ def debug(msg):
 # Run system commands (outside of Python)
 ########################################################################################################################
 def run_sys_cmd(description, islocal, cmd, report_errors=True, show_log=True):
-    if islocal:
-        target = 'local'
-    else:
-        target = 'remote'
-    retry_cnt = 0
-    while retry_cnt < 6:
-        if show_log:
-            debug(description)
-        if show_log:
-            debug("SHELL CMD (%s): %s" % (target, cmd))
-        retcode = run(cmd, shell=True, capture_output=True, text=True)
-        if retcode.returncode != 0:
-            if report_errors:
-                error("Failure: %s" % description + " Retrying...")
-                debug("Failed command output is: %s %s" % (str(retcode.stdout), str(retcode.stderr)))
-            retry_cnt = retry_cnt + 1
-            time.sleep(1.3)
-        else:
-            if show_log:
-                success("Success: %s" % description)
-            break
-        if retry_cnt == 6:
-            error("Giving up...")
-    return retcode.stdout
-
-########################################################################################################################
-# Run system commands (outside of Python) -- no retry
-########################################################################################################################
-def run_sys_cmd_nr(description, islocal, cmd, report_errors=True, show_log=True):
     if islocal:
         target = 'local'
     else:
@@ -190,9 +162,8 @@ def cleanup(proxy=None, cannon=None):
             debug("Attempting to terminate instance: %s" % str(instance.id))
             instance.terminate()
 
-        warning("Pausing for 2 minutes so instances can properly terminate.....")
+        warning("Pausing for 120 seconds so instances can properly terminate.....")
         time.sleep(120)
-    print("\n")
     conn.get_all_addresses(filters={"tag:Name": nameTag})
 
     # Detect Elastic IPs and remove them if needed
@@ -314,7 +285,7 @@ def rotate_host(target_tunnel_id, show_log=True):
         if tunnels[tunnel_id]['route_active'] and tunnels[tunnel_id]['tunnel_active'] and \
                 tunnels[tunnel_id]['link_state_active'] and tunnels[tunnel_id]['tunnel_works'] and \
                 not tunnels[tunnel_id]['rotating_ip']:
-            nexthopcmd = nexthopcmd + "nexthop via 172.31.%s.2 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
+            nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
             # As we are using multipath routing and will do route cache-busting elsewhere
             # it is (probably?) good enough to do ECMP here (i.e. weight = 1 for all routes)
             routes_available = True
@@ -503,24 +474,22 @@ def rotate_host(target_tunnel_id, show_log=True):
 
             # Provision remote tun interface
             run_sys_cmd("Setting IP on remote tun adapter (tun%s)" % target_tunnel_id, False, sshbasecmd +
-                        "'sudo ifconfig tun%s 172.31.%s.2 netmask 255.255.0.0'" %
+                        "'sudo ifconfig tun%s 10.%s.254.1 netmask 255.255.255.252'" %
                         (target_tunnel_id, target_tunnel_id), show_log=show_log)
 
         # Check if we need the return route re-adding or not
         return_routes = run_sys_cmd("Check if we need the return route re-adding or not (tun%s)" % target_tunnel_id,
-                                    False, sshbasecmd + "'ip route list dev tun%s 172.31.%s.2/16'" %
+                                    False, sshbasecmd + "'ip route list dev tun%s 10.%s.254.2/32'" %
                                     (target_tunnel_id, target_tunnel_id), show_log=show_log)
         if return_routes == '':
             # Add return route back to us
             run_sys_cmd("Adding return route back to us (tun%s)" % target_tunnel_id, False, sshbasecmd +
-                        "'sudo route add 172.31.%s.2 dev tun%s'" %
+                        "'sudo route add 10.%s.254.2 dev tun%s'" %
                         (target_tunnel_id, target_tunnel_id), show_log=show_log)
-        # Establish tunnel
-        #sshcmd = "ssh -i %s/.ssh/%s.pem -o StrictHostKeyChecking=no -w %s:%s -o TCPKeepAlive=yes -o " \
-        #         "ServerAliveInterval=50 ubuntu@%s &" % (homeDir, keyName, target_tunnel_id, target_tunnel_id, swapped_ip)
-        sshcmd = "sshuttle --dns -r ubuntu@%s 0/0 -x %s:22 --ssh-cmd 'ssh -i %s/.ssh/%s.pem -o StrictHostKeyChecking=no -w %s:%s -o TCPKeepAlive=yes -o " \
-                 "ServerAliveInterval=50' &" % (swapped_ip, swapped_ip, homeDir, keyName, target_tunnel_id, target_tunnel_id)
 
+        # Establish tunnel
+        sshcmd = "ssh -i %s/.ssh/%s.pem -o StrictHostKeyChecking=no -w %s:%s -o TCPKeepAlive=yes -o " \
+                 "ServerAliveInterval=50 ubuntu@%s &" % (homeDir, keyName, target_tunnel_id, target_tunnel_id, swapped_ip)
         if show_log:
             debug('SHELL CMD (remote): %s (tun%s)' % (sshcmd, target_tunnel_id))
         retry_cnt = 0
@@ -551,9 +520,9 @@ def rotate_host(target_tunnel_id, show_log=True):
 
         # Provision interface
         run_sys_cmd("Provision interface (tun%s)" % target_tunnel_id, True, localcmdsudoprefix +
-                    "ifconfig tun%s 172.31.%s.2 netmask 255.255.0.0" % (target_tunnel_id,
+                    "ifconfig tun%s 10.%s.254.2 netmask 255.255.255.252" % (target_tunnel_id,
                                                                             target_tunnel_id), show_log=show_log)
-        time.sleep(1.3)
+        time.sleep(2)
 
         # Allow local connections to the proxy server
         run_sys_cmd("Allow connections to our proxy servers (tun%s)" % target_tunnel_id, True, localcmdsudoprefix +
@@ -572,7 +541,7 @@ def rotate_host(target_tunnel_id, show_log=True):
             # don't include the host we are tearing down in the multipath routing or any others that have been disabled
             if tunnels[tunnel_id]['route_active'] and tunnels[tunnel_id]['tunnel_active'] and \
                     tunnels[tunnel_id]['link_state_active'] and tunnels[tunnel_id]['tunnel_works']:
-                nexthopcmd = nexthopcmd + "nexthop via 192.168.%s.2 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
+                nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
                 # As we are using multipath routing and will do route cache-busting elsewhere
                 # it is (probably?) good enough to do ECMP here (i.e. weight = 1 for all routes)
             elif not tunnels[tunnel_id]['rotating_ip']:
@@ -632,7 +601,7 @@ def cache_bust(show_log=True):
         if tunnels[tunnel_id]['tunnel_active'] and tunnels[tunnel_id]['route_active'] \
                 and tunnels[tunnel_id]['link_state_active'] and tunnels[tunnel_id]['tunnel_works']\
                 and not tunnels[tunnel_id]['rotating_ip']:
-            nexthopcmd = nexthopcmd + "nexthop via 172.31.%s.2 dev tun%s weight %s " % \
+            nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight %s " % \
                          (tunnel_id, tunnel_id, random_weights[tunnel_id])
         elif not tunnels[tunnel_id]['rotating_ip']:
             debug("Tunnel tun%s excluded route table (Route %s - Tunnel %s - Link %s - Transmits %s)" %
@@ -642,7 +611,7 @@ def cache_bust(show_log=True):
     # sleep for half a second to help ensure the subsequent cache flush doesn't happen before the route as been applied
     # there is apparent bias in this mechanism for one route over the others and it isn't clear as to what the cause is
     # hoping that it is just a race condition
-    time.sleep(1)
+    time.sleep(0.5)
     run_sys_cmd("Flushing route cache", True, localcmdsudoprefix + 'ip route flush cache', show_log=show_log)
 
 
@@ -653,7 +622,7 @@ def cache_bust_thread_handler():
     # check if the exit flag has been set
     while not exit_threads:
         cache_bust(show_log=False)
-        time.sleep(1.2)
+        time.sleep(2)
 
 
 ########################################################################################################################
@@ -728,9 +697,9 @@ def tunnel_health_monitor_thread_handler():
                         # only include the tunnel that are marked as active in the ECMP routing
                         if tunnels[tunnel_id]['tunnel_active'] and tunnels[tunnel_id]['route_active'] \
                                 and tunnels[tunnel_id]['link_state_active'] and tunnels[tunnel_id]['tunnel_works']:
-                            nexthopcmd = nexthopcmd + "nexthop via 172.31.%s.2 dev tun%s weight 1 " % \
+                            nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight 1 " % \
                                          (tunnel_id, tunnel_id)
-                    run_sys_cmd_nr("Insert custom route (tunnel_health_monitor)", True,
+                    run_sys_cmd("Insert custom route (tunnel_health_monitor)", True,
                                 localcmdsudoprefix + nexthopcmd, show_log=False)
                     # update is no longer needed so reset the flag
                     update_needed = False
@@ -810,14 +779,14 @@ def main():
         error("There may be config in your AWS console to tidy up but no local changes were made")
         exit()
 
-    warning("Starting %s instances, waiting about 2 minutes for them to fully boot" % args.num_of_instances)
+    warning("Starting %s instances, waiting about 4 minutes for them to fully boot" % args.num_of_instances)
 
-    # sleep for 2 minutes while booting images
+    # sleep for 4 minutes while booting images
     for i in range(21):
         sys.stdout.write('\r')
         sys.stdout.write("[%-20s] %d%%" % ('=' * i, 5 * i))
         sys.stdout.flush()
-        time.sleep(5.75)
+        time.sleep(11.5)
     print("\n")
     # Add tag name to instance for better management
     for instance in reservations.instances:
@@ -836,55 +805,63 @@ def main():
         public_ips = public_ips + instance.ip_address + " "
         tunnel_id += 1
     debug("Public IP's for all instances: %s" % public_ips)
+
     # Create ssh Tunnels for proxying
     success("Provisioning Hosts.....")
     for tunnel_id, tunnel in tunnels.items():
         log(tunnels[tunnel_id]['pub_ip'])
         sshbasecmd = "ssh -i %s/.ssh/%s.pem -o StrictHostKeyChecking=no ubuntu@%s " % (
             homeDir, keyName, tunnels[tunnel_id]['pub_ip'])
+
         # Enable Tunneling on the remote host
         run_sys_cmd("Enabling tunneling via SSH on %s (tun%s)" % (tunnels[tunnel_id]['pub_ip'], tunnel_id), False, sshbasecmd +
                     "'echo \"PermitTunnel yes\" | sudo tee -a  /etc/ssh/sshd_config'")
+
         # Restarting Service to take new config (you'd think a simple reload would be enough)
         run_sys_cmd("Restarting Service to take new config on %s (tun%s)" % (tunnels[tunnel_id]['pub_ip'], tunnel_id), False,
                     sshbasecmd +
                     "'sudo service ssh restart'")
+
         # Provision interface
         run_sys_cmd("Provisioning tun%s interface on %s" % (tunnel_id, tunnels[tunnel_id]['pub_ip']), False, sshbasecmd +
                     "'sudo ip tuntap add dev tun%s mode tun'" % tunnel_id)
+
         # Configure interface
         run_sys_cmd("Configuring tun%s interface on %s" % (tunnel_id, tunnels[tunnel_id]['pub_ip']), False, sshbasecmd +
-                    "'sudo ifconfig tun%s 172.31.%s.2 netmask 255.255.0.0'" % (tunnel_id, tunnel_id))
+                    "'sudo ifconfig tun%s 10.%s.254.1 netmask 255.255.255.252'" % (tunnel_id, tunnel_id))
+
         # Enable forwarding on remote host
         run_sys_cmd("Enable forwarding on remote host (tun%s)" % tunnel_id, False,
                     sshbasecmd + "'sudo su root -c \"echo 1 > "
                                  "/proc/sys/net/ipv4/ip_forward\"'")
+
         # Provision iptables on remote host
         run_sys_cmd("Provision iptables on remote host (tun%s)" % tunnel_id, False,
                     sshbasecmd + "'sudo iptables -t nat -A POSTROUTING "
                                  "-o eth0 -j MASQUERADE'")
+
         # Add return route back to us
         run_sys_cmd("Add return route back to us (tun%s)" % tunnel_id, False,
-                    sshbasecmd + "'sudo route add 192.168.%s.2 dev tun%s'"
+                    sshbasecmd + "'sudo route add 10.%s.254.2 dev tun%s'"
                     % (tunnel_id, tunnel_id))
+
         # Create tun interface
         run_sys_cmd("Creating local interface tun%s" % str(tunnel_id), True, localcmdsudoprefix +
                     "ip tuntap add dev tun%s mode tun" % str(tunnel_id))
+
         # Turn up our interface
         run_sys_cmd("Turning up interface tun%s" % str(tunnel_id), True, localcmdsudoprefix +
                     "ifconfig tun%s up" % tunnel_id)
-        # Provision interface
-        run_sys_cmd("Assigning interface tun" + str(tunnel_id) + " ip of 192.168." + str(tunnel_id) + ".2", True,
-                    localcmdsudoprefix + "ifconfig tun%s 192.168.%s.2 netmask 255.255.0.0" % (tunnel_id, tunnel_id))
-        time.sleep(0.5)
-        # Establish tunnel interface
-        #sshcmd = "ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o " \
-        #         "ServerAliveInterval=50 ubuntu@%s &" % \
-        #         (homeDir, keyName, tunnel_id, tunnel_id, tunnels[tunnel_id]['pub_ip'])
-        sshcmd = "sshuttle --dns -r ubuntu@%s 0/0 -x %s:22 --ssh-cmd " \
-                 "'ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=50' &" \
-                 % (tunnels[tunnel_id]['pub_ip'], tunnels[tunnel_id]['pub_ip'], homeDir, keyName, tunnel_id, tunnel_id)
 
+        # Provision interface
+        run_sys_cmd("Assigning interface tun" + str(tunnel_id) + " ip of 10." + str(tunnel_id) + ".254.2", True,
+                    localcmdsudoprefix + "ifconfig tun%s 10.%s.254.2 netmask 255.255.255.252" % (tunnel_id, tunnel_id))
+        time.sleep(0.5)
+
+        # Establish tunnel interface
+        sshcmd = "ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o " \
+                 "ServerAliveInterval=50 ubuntu@%s &" % \
+                 (homeDir, keyName, tunnel_id, tunnel_id, tunnels[tunnel_id]['pub_ip'])
         debug("SHELL CMD (remote): " + sshcmd)
         retry_cnt = 0
         while retry_cnt < 6:
@@ -925,15 +902,15 @@ def main():
     run_sys_cmd("Flushing all remaining local iptables rules", True, localcmdsudoprefix + "iptables -w 2 -F")
 
     # Allow local connections to RFC1918 (1 of 3)
-    run_sys_cmd("Allowing local connections to RFC1918 (1 of 4)", True, localcmdsudoprefix +
+    run_sys_cmd("Allowing local connections to RFC1918 (1 of 3)", True, localcmdsudoprefix +
                 "iptables -w 2 -t nat -I POSTROUTING -d 192.168.0.0/16 -j RETURN")
 
     # Allow local connections to RFC1918 (2 of 3)
-    run_sys_cmd("Allowing local connections to RFC1918 (2 of 4)", True, localcmdsudoprefix +
+    run_sys_cmd("Allowing local connections to RFC1918 (2 of 3)", True, localcmdsudoprefix +
                 "iptables -w 2 -t nat -I POSTROUTING -d 172.16.0.0/16 -j RETURN")
 
     # Allow local connections to RFC1918 (3 of 3)
-    run_sys_cmd("Allowing local connections to RFC1918 (3 of 4)", True, localcmdsudoprefix +
+    run_sys_cmd("Allowing local connections to RFC1918 (3 of 3)", True, localcmdsudoprefix +
                 "iptables -w 2 -t nat -I POSTROUTING -d 10.0.0.0/8 -j RETURN")
 
     # do routing and ip tables for each of the tunnel hosts, including build the ECMP route
@@ -948,7 +925,7 @@ def main():
                     "iptables -w 2 -t nat -A POSTROUTING -o tun%s -j MASQUERADE " % tunnel_id)
 
         # Build ECMP route table command
-        nexthopcmd = nexthopcmd + "nexthop via 172.31.%s.2 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
+        nexthopcmd = nexthopcmd + "nexthop via 10.%s.254.1 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
 
         # Mark route as active
         tunnels[tunnel_id]['route_active'] = True
@@ -975,7 +952,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-id', '--image-id', nargs='?', default='ami-0650b4d1b221600a5',
                     help="Amazon ami image ID.  Example: ami-0650b4d1b221600a5. If not set, ami-0650b4d1b221600a5.")
 parser.add_argument('-t', '--image-type', nargs='?', default='t2.nano',
-                    help="Amazon ami image type Example: t2.micro. If not set, defaults to t2.nano.")
+                    help="Amazon ami image type Example: t2.nano. If not set, defaults to t2.nano.")
 parser.add_argument('--region', nargs='?', default='us-east-2',
                     help="Select the region: Example: us-east-2. If not set, defaults to us-east-2.")
 parser.add_argument('-r', action='store_true', help="Enable Rotating AMI hosts.")
@@ -1153,4 +1130,4 @@ if __name__ == '__main__':
             for tunnel_id, tunnel in tunnels.items():
                 rotate_host(tunnel_id)
         # the below sleep is just to stop wild things from happening until proper timing control is implemented.
-        time.sleep(3)
+        time.sleep(5)

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -488,8 +488,11 @@ def rotate_host(target_tunnel_id, show_log=True):
                         (target_tunnel_id, target_tunnel_id), show_log=show_log)
 
         # Establish tunnel
-        sshcmd = "ssh -i %s/.ssh/%s.pem -o StrictHostKeyChecking=no -w %s:%s -o TCPKeepAlive=yes -o " \
-                 "ServerAliveInterval=50 ubuntu@%s &" % (homeDir, keyName, target_tunnel_id, target_tunnel_id, swapped_ip)
+        #sshcmd = "ssh -i %s/.ssh/%s.pem -o StrictHostKeyChecking=no -w %s:%s -o TCPKeepAlive=yes -o " \
+        #         "ServerAliveInterval=50 ubuntu@%s &" % (homeDir, keyName, target_tunnel_id, target_tunnel_id, swapped_ip)
+        sshcmd = "sshuttle --dns -r ubuntu@%s 0/0 -x %s:22 --ssh-cmd 'ssh -i %s/.ssh/%s.pem -o StrictHostKeyChecking=no -w %s:%s -o TCPKeepAlive=yes -o " \
+                 "ServerAliveInterval=50' &" % (swapped_ip, swapped_ip, homeDir, keyName, target_tunnel_id, target_tunnel_id)
+
         if show_log:
             debug('SHELL CMD (remote): %s (tun%s)' % (sshcmd, target_tunnel_id))
         retry_cnt = 0
@@ -859,9 +862,13 @@ def main():
         time.sleep(0.5)
 
         # Establish tunnel interface
-        sshcmd = "ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o " \
-                 "ServerAliveInterval=50 ubuntu@%s &" % \
-                 (homeDir, keyName, tunnel_id, tunnel_id, tunnels[tunnel_id]['pub_ip'])
+        #sshcmd = "ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o " \
+        #         "ServerAliveInterval=50 ubuntu@%s &" % \
+        #         (homeDir, keyName, tunnel_id, tunnel_id, tunnels[tunnel_id]['pub_ip'])
+        sshcmd = "sshuttle --dns -r ubuntu@%s 0/0 -x %s:22 --ssh-cmd " \
+                 "'ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=50' &" \
+                 % (tunnels[tunnel_id]['pub_ip'], tunnels[tunnel_id]['pub_ip'], homeDir, keyName, tunnel_id, tunnel_id)        
+        
         debug("SHELL CMD (remote): " + sshcmd)
         retry_cnt = 0
         while retry_cnt < 6:

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -997,8 +997,8 @@ def main():
 # System and Program Arguments
 ########################################################################################################################
 parser = argparse.ArgumentParser()
-parser.add_argument('-id', '--image-id', nargs='?', default='ami-0650b4d1b221600a5',
-                    help="Amazon ami image ID.  Example: ami-0650b4d1b221600a5. If not set, ami-0650b4d1b221600a5.")
+parser.add_argument('-id', '--image-id', nargs='?', default='ami-0ccd41bf9f4fafa80',
+                    help="Amazon ami image ID.  Example: ami-0ccd41bf9f4fafa80. If not set, ami-0ccd41bf9f4fafa80.")
 parser.add_argument('-t', '--image-type', nargs='?', default='t2.nano',
                     help="Amazon ami image type Example: t2.nano. If not set, defaults to t2.nano.")
 parser.add_argument('--region', nargs='?', default='us-east-2',

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -543,7 +543,7 @@ def rotate_host(target_tunnel_id, show_log=True):
                 tunnels[target_tunnel_id]['tunnel_pid'] = str(ssh_tunnel_pid)
                 tunnels[target_tunnel_id]['tunnel_active'] = True
                 break
-            if retry_cnt == 5:
+            if retry_cnt == 6:
                 error("Giving up...")
 
         # Turn up our interface
@@ -917,7 +917,7 @@ def main():
                 # mark tunnel as active
                 tunnels[tunnel_id]['tunnel_active'] = True
                 break
-            if retry_cnt == 5:
+            if retry_cnt == 6:
                 error("Giving up...")
 
     # setup local forwarding

--- a/proxycannon.py
+++ b/proxycannon.py
@@ -572,7 +572,7 @@ def rotate_host(target_tunnel_id, show_log=True):
             # don't include the host we are tearing down in the multipath routing or any others that have been disabled
             if tunnels[tunnel_id]['route_active'] and tunnels[tunnel_id]['tunnel_active'] and \
                     tunnels[tunnel_id]['link_state_active'] and tunnels[tunnel_id]['tunnel_works']:
-                nexthopcmd = nexthopcmd + "nexthop via 172.31.%s.2 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
+                nexthopcmd = nexthopcmd + "nexthop via 192.168.%s.2 dev tun%s weight 1 " % (tunnel_id, tunnel_id)
                 # As we are using multipath routing and will do route cache-busting elsewhere
                 # it is (probably?) good enough to do ECMP here (i.e. weight = 1 for all routes)
             elif not tunnels[tunnel_id]['rotating_ip']:
@@ -865,7 +865,7 @@ def main():
                                  "-o eth0 -j MASQUERADE'")
         # Add return route back to us
         run_sys_cmd("Add return route back to us (tun%s)" % tunnel_id, False,
-                    sshbasecmd + "'sudo route add 172.31.%s.2 dev tun%s'"
+                    sshbasecmd + "'sudo route add 192.168.%s.2 dev tun%s'"
                     % (tunnel_id, tunnel_id))
         # Create tun interface
         run_sys_cmd("Creating local interface tun%s" % str(tunnel_id), True, localcmdsudoprefix +
@@ -874,16 +874,16 @@ def main():
         run_sys_cmd("Turning up interface tun%s" % str(tunnel_id), True, localcmdsudoprefix +
                     "ifconfig tun%s up" % tunnel_id)
         # Provision interface
-        run_sys_cmd("Assigning interface tun" + str(tunnel_id) + " ip of 192.168.229." + str(tunnel_id), True,
-                    localcmdsudoprefix + "ifconfig tun%s 172.31.%s.2 netmask 255.255.255.0" % (tunnel_id, tunnel_id))
+        run_sys_cmd("Assigning interface tun" + str(tunnel_id) + " ip of 192.168." + str(tunnel_id) + ".2", True,
+                    localcmdsudoprefix + "ifconfig tun%s 192.168.%s.2 netmask 255.255.0.0" % (tunnel_id, tunnel_id))
         time.sleep(0.5)
         # Establish tunnel interface
-        sshcmd = "ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o " \
-                 "ServerAliveInterval=50 ubuntu@%s &" % \
-                 (homeDir, keyName, tunnel_id, tunnel_id, tunnels[tunnel_id]['pub_ip'])
-        #sshcmd = "sshuttle --dns -r ubuntu@%s 0/0 -x %s:22 --ssh-cmd " \
-        #         "'ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=50' &" \
-        #         % (tunnels[tunnel_id]['pub_ip'], tunnels[tunnel_id]['pub_ip'], homeDir, keyName, tunnel_id, tunnel_id)
+        #sshcmd = "ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o " \
+        #         "ServerAliveInterval=50 ubuntu@%s &" % \
+        #         (homeDir, keyName, tunnel_id, tunnel_id, tunnels[tunnel_id]['pub_ip'])
+        sshcmd = "sshuttle --dns -r ubuntu@%s 0/0 -x %s:22 --ssh-cmd " \
+                 "'ssh -i %s/.ssh/%s.pem -w %s:%s -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=50' &" \
+                 % (tunnels[tunnel_id]['pub_ip'], tunnels[tunnel_id]['pub_ip'], homeDir, keyName, tunnel_id, tunnel_id)
 
         debug("SHELL CMD (remote): " + sshcmd)
         retry_cnt = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto~=2.49.0
 netifaces~=0.10.9
+sshuttle~=1.1.1


### PR DESCRIPTION
I needed to use this for web traffic, meaning I had to enable tunneling for udp(dns), so I changed the tunneling method to sshuttle which enables for greater flexibility and versatility -- and more connections. 

in this current state, there are no errors or crashes, cleanup is pristine. 

Cache busting appears to have broken, though I'm not sure if that was functioning initially and it's outside my purview. 
 